### PR TITLE
Add 1 day cache for some endpoints

### DIFF
--- a/src/endpoints/categories.rs
+++ b/src/endpoints/categories.rs
@@ -10,6 +10,6 @@ use data::schema::categories::dsl::*;
 use lib::responders::*;
 
 #[get("/categories")]
-pub fn get_categories(conn: DbConn) -> QueryResult<Cors<Json<Vec<Category>>>> {
-    categories.load::<Category>(&*conn).map(Json).map(Cors)
+pub fn get_categories(conn: DbConn) -> QueryResult<Cached<Cors<Json<Vec<Category>>>>> {
+    categories.load::<Category>(&*conn).map(Json).map(Cors).map(Cached)
 }

--- a/src/endpoints/votes.rs
+++ b/src/endpoints/votes.rs
@@ -30,7 +30,7 @@ pub struct GetVotesResponse {
 }
 
 #[get("/votes?<params>")]
-fn get_votes(params: GetVotesParams, conn: DbConn) -> QueryResult<Cors<Json<GetVotesResponse>>> {
+fn get_votes(params: GetVotesParams, conn: DbConn) -> QueryResult<Cached<Cors<Json<GetVotesResponse>>>> {
     let mut robinho_votes = vec![];
     let mut people_votes = vec![];
 
@@ -41,11 +41,11 @@ fn get_votes(params: GetVotesParams, conn: DbConn) -> QueryResult<Cors<Json<GetV
         people_votes = get_people_votes(&params.url, &*conn)?;
     }
 
-    Ok(Cors(Json(GetVotesResponse {
+    Ok(Cached(Cors(Json(GetVotesResponse {
         verified: None,
         robot: robinho_votes,
         people: people_votes,
-    })))
+    }))))
 }
 
 #[derive(Deserialize)]

--- a/src/lib/responders.rs
+++ b/src/lib/responders.rs
@@ -14,3 +14,16 @@ impl<'r, R: Responder<'r>> Responder<'r> for Cors<R> {
             .ok()
     }
 }
+
+
+pub struct Cached<R>(pub R);
+
+impl<'r, R: Responder<'r>> Responder<'r> for Cached<R> {
+    #[inline(always)]
+    fn respond_to(self, req: &Request) -> Result<Response<'r>, Status> {
+        Response::build()
+            .merge(self.0.respond_to(req)?)
+            .raw_header("Cache-Control", "max-age=86400") // 1 day
+            .ok()
+    }
+}


### PR DESCRIPTION
According to this: https://support.cloudflare.com/hc/en-us/articles/202775670-How-Do-I-Tell-Cloudflare-What-to-Cache-

cloudflare should respect that caching header and cache it

this could avoid the number of requests to the server for a very popular news for example